### PR TITLE
Credentials error from pykeepass

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ make build
 ```
 
 ## Run/usage
-- First you will need to **create new (empty) KeePass database** (tested with [KeePassXC](https://github.com/keepassxreboot/keepassxc) but it will probably work with others)
+- You can either **create new (empty) KeePass database** (tested with [KeePassXC](https://github.com/keepassxreboot/keepassxc) but it will probably work with others) right now, otherwise one will be created when the script is executed
 - Go into the virtual environment
 ```
 source .venv/bin/activate

--- a/bitwarden-to-keepass.py
+++ b/bitwarden-to-keepass.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 from shlex import quote
 
 from pykeepass import PyKeePass, create_database
-from pykeepass.exceptions import CredentialsIntegrityError
+from pykeepass.exceptions import CredentialsError
 
 from item import Item, Types as ItemTypes
 
@@ -20,7 +20,7 @@ def bitwarden_to_keepass(args):
     except FileNotFoundError:
         logging.info('KeePass database does not exist, creating a new one.')
         kp = create_database(args.database_path, password=args.database_password, keyfile=args.database_keyfile)
-    except CredentialsIntegrityError as e:
+    except CredentialsError as e:
         logging.error(f'Wrong password for KeePass database: {e}')
         return
 


### PR DESCRIPTION
It seems that pykeepass~3.2 doesn't include a `CredentialsIntegrityError`, but it does include a `CredentialsError`.