### PR TITLE
Downloading the CLI directly instead of using npm

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ DATABASE_PASSWORD=CHANGE_ME
 #DATABASE_KEYFILE=
 BW_PATH=/usr/local/bin/bw
 DATABASE_PATH=/exports/bitwarden-export.kdbx
+BITWARDEN_URL=https://bitwarden.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11.0-slim-bullseye
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends wget unzip && \
     wget -O "bw.zip" "https://vault.bitwarden.com/download/?app=cli&platform=linux" && \
     unzip bw.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM tangowithfoxtrot/bw-cli as builder
-
 FROM python:3.11.0-slim-bullseye
 
-COPY --from=builder /usr/local/bin/bw /bin/bw
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget unzip && \
+    wget -O "bw.zip" "https://vault.bitwarden.com/download/?app=cli&platform=linux" && \
+    unzip bw.zip && \
+    chmod +x ./bw && \
+    mv ./bw /usr/local/bin/bw && \
+    apt-get purge -y --auto-remove wget unzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf bw.zip
 
 WORKDIR /bitwarden-to-keepass
-
 COPY . .
 
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM python:3.11-slim-bookworm
-
-RUN apt update && apt install -y npm && \
-    npm i -g @bitwarden/cli && \
-    apt purge -y npm
+FROM python:3.11.0-slim-bullseye
 
 WORKDIR /bitwarden-to-keepass
-
-COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
-
 COPY . .
+
+RUN apt-get update && \
+    apt-get install -y unzip curl jq && \
+    # Taken from https://github.com/tangowithfoxtrot/bw-docker/blob/main/Dockerfile#L7
+    export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq  -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
+    curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v{$VER}/bw-linux-{$VER}.zip" && \
+    unzip *.zip && chmod +x ./bw && \
+    mv bw /bin/ && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apt-get purge -y --auto-remove unzip curl jq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,33 @@
+# First stage: Download and extract the Bitwarden CLI
+FROM python:3.11.0-slim-bullseye as builder
+
+# Install dependencies for downloading and extracting Bitwarden CLI
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl jq unzip
+
+# Download and extract Bitwarden CLI
+# Taken from https://github.com/tangowithfoxtrot/bw-docker/blob/main/Dockerfile#L7
+RUN export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
+    curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v${VER}/bw-linux-${VER}.zip" && \
+    unzip *.zip && \
+    chmod +x ./bw
+
+# Second stage: Build the final image
 FROM python:3.11.0-slim-bullseye
 
+# Copy Bitwarden CLI from the builder stage
+COPY --from=builder /bw /bin/bw
+
+# Set up the working directory
 WORKDIR /bitwarden-to-keepass
+
+# Copy the application files
 COPY . .
 
-RUN apt-get update && \
-    apt-get install -y unzip curl jq && \
-    # Taken from https://github.com/tangowithfoxtrot/bw-docker/blob/main/Dockerfile#L7
-    export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq  -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
-    curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v{$VER}/bw-linux-{$VER}.zip" && \
-    unzip *.zip && chmod +x ./bw && \
-    mv bw /bin/ && \
-    pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt && \
-    apt-get purge -y --auto-remove unzip curl jq && \
-    apt-get clean && \
+# Install Python dependencies
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Clean up unnecessary files to reduce image size
+RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.11-slim-bookworm
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends wget unzip && \
     wget -O "bw.zip" "https://vault.bitwarden.com/download/?app=cli&platform=linux" && \
     unzip bw.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get update && \
     rm -rf bw.zip
 
 WORKDIR /bitwarden-to-keepass
-COPY . .
+COPY requirements.txt ./
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,12 @@
-# First stage: Download and extract the Bitwarden CLI
-FROM python:3.11.0-slim-bullseye as builder
+FROM tangowithfoxtrot/bw-cli as builder
 
-# Install dependencies for downloading and extracting Bitwarden CLI
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl jq unzip
-
-# Download and extract Bitwarden CLI
-# Taken from https://github.com/tangowithfoxtrot/bw-docker/blob/main/Dockerfile#L7
-RUN export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
-    curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v${VER}/bw-linux-${VER}.zip" && \
-    unzip *.zip && \
-    chmod +x ./bw
-
-# Second stage: Build the final image
 FROM python:3.11.0-slim-bullseye
 
-# Copy Bitwarden CLI from the builder stage
-COPY --from=builder /bw /bin/bw
+COPY --from=builder /usr/local/bin/bw /bin/bw
 
-# Set up the working directory
 WORKDIR /bitwarden-to-keepass
 
-# Copy the application files
 COPY . .
 
-# Install Python dependencies
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
-
-# Clean up unnecessary files to reduce image size
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It uses official [bitwarden-cli](https://bitwarden.com/help/article/cli/) client
 - Clone this repository
 - Edit `.env` file
   - ⚠️ make sure to set your own `DATABASE_PASSWORD` - used as password for KeePass database
+  - If you are using a custom Bitwarden instance, set the URL in `BITWARDEN_URL`
 - Run
 ```
 docker-compose run bitwarden-to-keepass

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   bitwarden-to-keepass:
     build: .
     command: >
-      bash -c 'export BW_SESSION=`$BW_PATH login --raw || $BW_PATH unlock --raw`
+      bash -c '$BW_PATH config server $BITWARDEN_URL && export BW_SESSION=`$BW_PATH login --raw || $BW_PATH unlock --raw`
       && $BW_PATH sync
       && python3 bitwarden-to-keepass.py
       && $BW_PATH lock'


### PR DESCRIPTION
Hi!

Thank you so much for your script! I'm working on a fork to make it work with Vaultwarden by default.

In the process, I made some quality improvements on the Dockerfile. Instead of installing the bw-cli from npm and depending on NodeJS, I downloaded the cli binary directly from a prebuilt image.

This made the size of the image go from ~1GB to 290MB. I think this can be improved further, but it is a huge reduction!

EDIT

Thanks to [this comment](https://github.com/davidnemec/bitwarden-to-keepass/pull/16#issuecomment-1954053250), this PR now closes #9 