### PR TITLE
Prompt user for database password if not supplied

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ source .venv/bin/activate
 - [Download](https://bitwarden.com/help/article/cli/#download-and-install) official bitwarden-cli and do `bw login` (you need `BW_SESSION` for export to work).
 - Run
 ```
-python3 bitwarden-to-keepass.py --bw-session BW_SESSION --database-path DATABASE_PATH --database-password DATABASE_PASSWORD [--database-keyfile DATABASE_KEYFILE] [--bw-path BW_PATH]
+python3 bitwarden-to-keepass.py --bw-session BW_SESSION --database-path DATABASE_PATH [--database-password DATABASE_PASSWORD] [--database-keyfile DATABASE_KEYFILE] [--bw-path BW_PATH]
 ```


### PR DESCRIPTION
This avoids leaving traces of the DB password floating around in the shell history.